### PR TITLE
Update to autostart

### DIFF
--- a/LiveSplit.Yakuza4.asl
+++ b/LiveSplit.Yakuza4.asl
@@ -45,7 +45,7 @@ onStart
 start 
 {
     // Start at choosing difficulty
-    return (current.FileTimer == 0 && current.Paradigm == 212);
+    return (current.Start > 0 && current.Paradigm == 212);
 
     // Start at the first title card, i.e. after the disclaimer in English
     // return (current.Paradigm == 185);


### PR DESCRIPTION
current.Start > 0 starts the timer more correctly, you had it right. FileTimer is only reset to 0 after the fade to black concludes, which is half a second later.