### PR TITLE
[Yakuza 3] Fixed title cards, fixed Mine split (Steam)

### DIFF
--- a/LiveSplit.Yakuza3.asl
+++ b/LiveSplit.Yakuza3.asl
@@ -1,32 +1,26 @@
 state("Yakuza3", "Steam") 
 {
     byte EnemyCount:  0x1198218, 0x200, 0x491;
-    short HPSlot0:    0x1198218, 0x200, 0xD0, 0x138, 0x1AC;
-    short HPSlot0Max: 0x1198218, 0x200, 0xD0, 0x138, 0x1AE;
     byte Loads: 0x1198218, 0x310, 0x210;
     string255 TitleCard: 0x1198218, 0x560, 0xC8, 0x108, 0x14;
     short Paradigm: 0x119D778;
     byte Start: 0x11C6524;
     byte LoadHelper: 0x11AB360;
     string255 GolfResults: 0x011C3470, 0x28, 0x5D4;
-    string255 Objective: 0x11B7898, 0x264, 0xFB0;
     int FileTimer: 0x11C6518;
+    byte MusicSlot2State: 0x128B048, 0x40;
     string255 MusicSlot2: 0x128B048, 0x5C;
-    byte MusicCursor2: 0x2A2BC60, 0x28, 0xC0, 0x0, 0x0, 0x0;
 }
 
 state("Yakuza3", "Game Pass") 
 {
     byte EnemyCount:  0x144D1C0, 0x200, 0x491;
-    short HPSlot0:    0x144D1C0, 0x200, 0xD0, 0x138, 0x1AC;
-    short HPSlot0Max: 0x144D1C0, 0x200, 0xD0, 0x138, 0x1AE;
     byte Loads: 0x144D1C0, 0x310, 0x210;
     string255 TitleCard: 0x11B9850, 0x108, 0x1B0, 0x52; // TODO: Find Game Pass address for this!
     short Paradigm: 0x1452738;
     byte Start: 0x1460340;
     byte LoadHelper: 0x11AB360; // TODO: Find Game Pass address for this!
     string255 GolfResults: 0x011C3470, 0x28, 0x5D4; // TODO: Find Game Pass address for this!
-    string255 Objective: 0x11B7898, 0x264, 0xFB0; // TODO: Find Game Pass address for this!
     int FileTimer: 0x147B498;
     string255 MusicSlot2: 0x128B048, 0x5C; // TODO: Find Game Pass address for this!
     byte MusicCursor2: 0x2A2BC60, 0x28, 0xC0, 0x0, 0x0, 0x0; // TODO: Find Game Pass address for this!
@@ -83,13 +77,11 @@ startup
 
     vars.GolfCaddy = new Stopwatch();
     vars.minimumtime = TimeSpan.FromSeconds(5);
-  
-    vars.EndingHelper = 0;
 }
 
 update
 {
-    print(modules.First().ModuleMemorySize.ToString());
+    //print(modules.First().ModuleMemorySize.ToString());
 
     if (vars.GolfCaddy.Elapsed >= vars.minimumtime) vars.GolfCaddy.Stop();
 }
@@ -115,15 +107,8 @@ split
     if (version != "Steam")
         return false;
 
-    // if(vars.EndingHelper == "Zero")
-    //     return false;
-
-    if(current.MusicSlot2.Contains("vs_mine2") && vars.EndingHelper == 0 && current.MusicCursor2 == 128)
-        vars.EndingHelper = 1;
-
-    else if (vars.EndingHelper == 1 && current.MusicCursor2 != 128)
+    if(current.MusicSlot2.Contains("vs_mine2") && old.MusicSlot2State == 2 && current.MusicSlot2State == 4)
     {
-        vars.EndingHelper = 2;
         return settings["RUN OVER"];
     }
 

--- a/LiveSplit.Yakuza3.asl
+++ b/LiveSplit.Yakuza3.asl
@@ -4,7 +4,7 @@ state("Yakuza3", "Steam")
     short HPSlot0:    0x1198218, 0x200, 0xD0, 0x138, 0x1AC;
     short HPSlot0Max: 0x1198218, 0x200, 0xD0, 0x138, 0x1AE;
     byte Loads: 0x1198218, 0x310, 0x210;
-    string255 TitleCard: 0x1198218, 0x560, 0xC8, 0x108, 0x57;
+    string255 TitleCard: 0x1198218, 0x560, 0xC8, 0x108, 0x14;
     short Paradigm: 0x119D778;
     byte Start: 0x11C6524;
     byte LoadHelper: 0x11AB360;
@@ -50,18 +50,18 @@ init {
 startup
 {   
     settings.Add("yak3", true, "Yakuza 3 - Chapter End Splits");
-        settings.Add("tle_02.dds", true, "Chapter 1: New Beginnings", "yak3");
-        settings.Add("tle_03.dds", true, "Chapter 2: The Ryudo Encounter", "yak3");
-        settings.Add("tle_04.dds", true, "Chapter 3: Power Struggle", "yak3");
-            settings.Add("golf", false, "Split after Golf", "tle_04.dds");
-        settings.Add("tle_05.dds", true, "Chapter 4: The Man in the Sketch", "yak3");
-        settings.Add("tle_06.dds", true, "Chapter 5: The Curtain Rises", "yak3");
-        settings.Add("tle_07.dds", true, "Chapter 6: Gameplan", "yak3");
-        settings.Add("tle_08.dds", true, "Chapter 7: The Mad Dog", "yak3");
-        settings.Add("tle_09.dds", true, "Chapter 8: Conspirators", "yak3");
-        settings.Add("tle_10.dds", true, "Chapter 9: The Plot", "yak3");
-        settings.Add("tle_11.dds", true, "Chapter 10: Unfinished Business", "yak3");
-        settings.Add("tle_12.dds", true, "Chapter 11: Crisis", "yak3");
+        settings.Add("syotitle_02.dds", true, "Chapter 1: New Beginnings", "yak3");
+        settings.Add("syotitle_03.dds", true, "Chapter 2: The Ryudo Encounter", "yak3");
+        settings.Add("syotitle_04.dds", true, "Chapter 3: Power Struggle", "yak3");
+            settings.Add("golf", false, "Split after Golf", "04.dds");
+        settings.Add("syotitle_05.dds", true, "Chapter 4: The Man in the Sketch", "yak3");
+        settings.Add("syotitle_06.dds", true, "Chapter 5: The Curtain Rises", "yak3");
+        settings.Add("syotitle_07.dds", true, "Chapter 6: Gameplan", "yak3");
+        settings.Add("syotitle_08.dds", true, "Chapter 7: The Mad Dog", "yak3");
+        settings.Add("syotitle_09.dds", true, "Chapter 8: Conspirators", "yak3");
+        settings.Add("syotitle_10.dds", true, "Chapter 9: The Plot", "yak3");
+        settings.Add("syotitle_11.dds", true, "Chapter 10: Unfinished Business", "yak3");
+        settings.Add("syotitle_12.dds", true, "Chapter 11: Crisis", "yak3");
         settings.Add("RUN OVER", true, "Chapter 12: The End of Ambition", "yak3");
 
     settings.SetToolTip("yak3", "Auto Splitter does not currently work on Game Pass version!");
@@ -130,7 +130,7 @@ split
     if (current.TitleCard != old.TitleCard && !vars.Splits.Contains(current.TitleCard))
     {
         vars.Splits.Add(current.TitleCard);
-        return settings[current.TitleCard.Substring(current.TitleCard.Length - 10)];
+        return settings[current.TitleCard.Substring(current.TitleCard.Length - 15)];
     }
 
     if (old.GolfResults == "on/mng19golf.par" && current.GolfResults != "on/mng19golf.par")

--- a/LiveSplit.Yakuza3.asl
+++ b/LiveSplit.Yakuza3.asl
@@ -53,7 +53,7 @@ startup
         settings.Add("syotitle_02.dds", true, "Chapter 1: New Beginnings", "yak3");
         settings.Add("syotitle_03.dds", true, "Chapter 2: The Ryudo Encounter", "yak3");
         settings.Add("syotitle_04.dds", true, "Chapter 3: Power Struggle", "yak3");
-            settings.Add("golf", false, "Split after Golf", "04.dds");
+            settings.Add("golf", false, "Split after Golf", "syotitle_04.dds");
         settings.Add("syotitle_05.dds", true, "Chapter 4: The Man in the Sketch", "yak3");
         settings.Add("syotitle_06.dds", true, "Chapter 5: The Curtain Rises", "yak3");
         settings.Add("syotitle_07.dds", true, "Chapter 6: Gameplan", "yak3");


### PR DESCRIPTION
There was a problem a while back where different people were getting different strings from the title card pointer, and we fixed it by just fudging the numbers around until it worked for everyone involved.

The problem was just that we weren't grabbing the string from its starting point. The string in question is an absolute path to the subtitle file, and different people have different installation directories on their hardware (for example, mine is F:/SteamLibrary/etc.), so that path would obviously be different for every installation. But if we grab the string at its starting point, and check against a substring a certain length from the end of the string, the result will be normalized to be the same for every user, regardless of the installation path.

(One key assumption I'm making is that the string pointer starts in the same position on every system. It should, and it would be strange if it didn't. But if anyone does experience an issue, it'll be easier to micro-adjust from the start of the string rather than coming at it from the end.)


- The Mine split should always work now. If this does somehow manage to break for anyone, there's another value that should work for MusicSlot2State at 0x28 instead of 0x40.