### PR TITLE
Yakuza 3, 4, 5 Run-End Split, autoreset, several fixes

### DIFF
--- a/LiveSplit.Yakuza3.asl
+++ b/LiveSplit.Yakuza3.asl
@@ -10,7 +10,7 @@ state("Yakuza3", "Steam")
     byte Start: 0x11C6524;
     byte MusicSlot2State: 0x128B048, 0x40;
     string255 MusicSlot2: 0x128B048, 0x5C;
-    string255 MusicSlot3: 0x128B048, 0x25C;
+    string255 AUXSlot1: 0x128B020, 0x5C;
 }
 
 state("Yakuza3", "Game Pass")
@@ -23,12 +23,12 @@ state("Yakuza3", "Game Pass")
     // string255 GolfResults: 0x11C3470, 0x28, 0x5D4; // TODO: Find Game Pass address for this!
     int FileTimer: 0x147B498;
     byte Start: 0x147B4A4;
-    byte MusicSlot2State: 0x153FE10, 0x40;
-    string255 MusicSlot2: 0x153FE10, 0x5C;
-    string255 MusicSlot3: 0x153FE10, 0x25C;
+    byte MusicSlot2State: 0x153FE38, 0x40;
+    string255 MusicSlot2: 0x153FE38, 0x5C;
+    string255 AUXSlot1: 0x153FE10, 0x5C;
 }
 
-state("Yakuza3", "GOG") //- 65900
+state("Yakuza3", "GOG")
 {
     byte EnemyCount: 0x1132918, 0x200, 0x491;
     byte Loads: 0x1132918, 0x310, 0x210;
@@ -40,7 +40,7 @@ state("Yakuza3", "GOG") //- 65900
     byte Start: 0x1160BD4;
     byte MusicSlot2State: 0x1225718, 0x40;
     string255 MusicSlot2: 0x1225718, 0x5C;
-    string255 MusicSlot3: 0x1225718, 0x25C;
+    string255 AUXSlot1: 0x12256F0, 0x5C;
 }
 
 init
@@ -127,7 +127,7 @@ split
     }
 
     if (!vars.Splits.Contains("GOLF")
-    && old.MusicSlot3.EndsWith("amb_golf.aix") && !current.MusicSlot3.EndsWith("amb_golf.aix"))
+    && old.AUXSlot1.EndsWith("amb_golf.aix") && !current.AUXSlot1.EndsWith("amb_golf.aix"))
     {
         vars.Splits.Add("GOLF");
         return settings["GOLF"];

--- a/LiveSplit.Yakuza3.asl
+++ b/LiveSplit.Yakuza3.asl
@@ -8,6 +8,8 @@ state("Yakuza3", "Steam")
     // string255 GolfResults: 0x11C3470, 0x28, 0x5A9;
     int FileTimer: 0x11C6518;
     byte Start: 0x11C6524;
+    byte MusicSlot1State: 0x128B040, 0x40;
+    string255 MusicSlot1: 0x128B040, 0x5C;
     byte MusicSlot2State: 0x128B048, 0x40;
     string255 MusicSlot2: 0x128B048, 0x5C;
     string255 AUXSlot1: 0x128B020, 0x5C;
@@ -20,9 +22,11 @@ state("Yakuza3", "Game Pass")
     string255 TitleCard: 0x144D1C0, 0x560, 0xC8, 0x108, 0x14;
     // short Paradigm: 0x1452738;
     byte LoadHelper: 0x1460340;
-    // string255 GolfResults: 0x11C3470, 0x28, 0x5D4; // TODO: Find Game Pass address for this!
+    // string255 GolfResults: 0x11C3470, 0x28, 0x5D4;
     int FileTimer: 0x147B498;
     byte Start: 0x147B4A4;
+    byte MusicSlot1State: 0x153FE30, 0x40;
+    string255 MusicSlot1: 0x153FE30, 0x5C;
     byte MusicSlot2State: 0x153FE38, 0x40;
     string255 MusicSlot2: 0x153FE38, 0x5C;
     string255 AUXSlot1: 0x153FE10, 0x5C;
@@ -38,6 +42,8 @@ state("Yakuza3", "GOG")
     // string255 GolfResults: 0x115DB70, 0x28, 0x5A9;
     int FileTimer: 0x1160BC8;
     byte Start: 0x1160BD4;
+    byte MusicSlot1State: 0x1225710, 0x40;
+    string255 MusicSlot1: 0x1225710, 0x5C;
     byte MusicSlot2State: 0x1225718, 0x40;
     string255 MusicSlot2: 0x1225718, 0x5C;
     string255 AUXSlot1: 0x12256F0, 0x5C;
@@ -128,10 +134,17 @@ split
 
     if (!vars.Splits.Contains("GOLF")
     && old.AUXSlot1.EndsWith("amb_golf.aix") && !current.AUXSlot1.EndsWith("amb_golf.aix"))
+    // && old.Paradigm == 1613 && current.Paradigm == 933)
     {
         vars.Splits.Add("GOLF");
         return settings["GOLF"];
     }
+}
+
+reset
+{
+    return current.MusicSlot1 == "data/sound/stream/title_def.adx" && current.MusicSlot1State == 4
+        || current.MusicSlot2 == "data/sound/stream/title_def.adx" && current.MusicSlot2State == 4;
 }
 
 onReset

--- a/LiveSplit.Yakuza3.asl
+++ b/LiveSplit.Yakuza3.asl
@@ -134,6 +134,11 @@ split
     }
 }
 
+onReset
+{
+    vars.Splits.Clear();
+}
+
 exit
 {
     timer.IsGameTimePaused = true;

--- a/LiveSplit.Yakuza3.asl
+++ b/LiveSplit.Yakuza3.asl
@@ -12,18 +12,19 @@ state("Yakuza3", "Steam")
     string255 MusicSlot2: 0x128B048, 0x5C;
     string255 MusicSlot3: 0x128B048, 0x25C;
 }
-
-state("Yakuza3", "Game Pass") 
+state("Yakuza3", "Game Pass")
 {
     byte EnemyCount:  0x144D1C0, 0x200, 0x491;
     byte Loads: 0x144D1C0, 0x310, 0x210;
-    string255 TitleCard: 0x11B9850, 0x108, 0x1B0, 0x52; // TODO: Find Game Pass address for this!
+    string255 TitleCard: 0x144D1C0, 0x560, 0xC8, 0x108, 0x14;
     // short Paradigm: 0x1452738;
-    byte Start: 0x1460340;
-    byte LoadHelper: 0x11AB360; // TODO: Find Game Pass address for this!
+    byte LoadHelper: 0x1460340;
     // string255 GolfResults: 0x11C3470, 0x28, 0x5D4; // TODO: Find Game Pass address for this!
     int FileTimer: 0x147B498;
-    string255 MusicSlot2: 0x128B048, 0x5C; // TODO: Find Game Pass address for this!
+    byte Start: 0x147B4A4;
+    byte MusicSlot2State: 0x153FE10, 0x40;
+    string255 MusicSlot2: 0x153FE10, 0x5C;
+    string255 MusicSlot3: 0x153FE10, 0x25C;
 }
 
 state("Yakuza3", "GOG") //- 65900

--- a/LiveSplit.Yakuza3.asl
+++ b/LiveSplit.Yakuza3.asl
@@ -5,13 +5,14 @@ state("Yakuza3", "Steam")
     string255 TitleCard: 0x1198218, 0x560, 0xC8, 0x108, 0x14;
     // short Paradigm: 0x119D778;
     byte LoadHelper: 0x11AB360;
-    // string255 GolfResults: 0x11C3470, 0x28, 0x5D4;
+    // string255 GolfResults: 0x11C3470, 0x28, 0x5A9;
     int FileTimer: 0x11C6518;
     byte Start: 0x11C6524;
     byte MusicSlot2State: 0x128B048, 0x40;
     string255 MusicSlot2: 0x128B048, 0x5C;
     string255 MusicSlot3: 0x128B048, 0x25C;
 }
+
 state("Yakuza3", "Game Pass")
 {
     byte EnemyCount:  0x144D1C0, 0x200, 0x491;
@@ -66,8 +67,8 @@ startup
     settings.Add("yak3", true, "Yakuza 3 - Chapter End Splits");
         settings.Add("syotitle_02.dds", true, "Chapter 1: New Beginnings", "yak3");
         settings.Add("syotitle_03.dds", true, "Chapter 2: The Ryudo Encounter", "yak3");
+        settings.Add("GOLF", false, "Split after Golf", "yak3");
         settings.Add("syotitle_04.dds", true, "Chapter 3: Power Struggle", "yak3");
-            settings.Add("golf", false, "Split after Golf", "syotitle_04.dds");
         settings.Add("syotitle_05.dds", true, "Chapter 4: The Man in the Sketch", "yak3");
         settings.Add("syotitle_06.dds", true, "Chapter 5: The Curtain Rises", "yak3");
         settings.Add("syotitle_07.dds", true, "Chapter 6: Gameplan", "yak3");
@@ -76,9 +77,9 @@ startup
         settings.Add("syotitle_10.dds", true, "Chapter 9: The Plot", "yak3");
         settings.Add("syotitle_11.dds", true, "Chapter 10: Unfinished Business", "yak3");
         settings.Add("syotitle_12.dds", true, "Chapter 11: Crisis", "yak3");
-        settings.Add("RUN OVER", true, "Chapter 12: The End of Ambition", "yak3");
+        settings.Add("RUN OVER", true, "End of the Run", "yak3");
 
-    settings.SetToolTip("yak3", "Auto Splitter does not currently work on Game Pass version!");
+    settings.SetToolTip("syotitle_02.dds", "Splits when Chapter 2 begins, and so on down the line.");
     settings.SetToolTip("RUN OVER", "Splits on the last hit on the final boss.");
 
     if (timer.CurrentTimingMethod == TimingMethod.RealTime)
@@ -125,11 +126,11 @@ split
         return settings[current.TitleCard.Substring(current.TitleCard.Length - 15)];
     }
 
-    if (!vars.Splits.Contains("golf")
+    if (!vars.Splits.Contains("GOLF")
     && old.MusicSlot3.EndsWith("amb_golf.aix") && !current.MusicSlot3.EndsWith("amb_golf.aix"))
     {
-        vars.Splits.Add("golf");
-        return settings["golf"];
+        vars.Splits.Add("GOLF");
+        return settings["GOLF"];
     }
 }
 

--- a/LiveSplit.Yakuza4.asl
+++ b/LiveSplit.Yakuza4.asl
@@ -11,13 +11,13 @@ state("Yakuza4", "Steam")
 
 state("Yakuza4", "Game Pass")
 {
-    byte EnemyCount: 0x197C440, 0x4B3;
-    byte Chapter: 0x197C838, 0x640, 0x204;
-    string255 TitleCard: 0x1993C38, 0x150, 0x1E4, 0x16C, 0x88, 0x28, 0x148, 0x14;
-    byte Character: 0x19806D0;      // 0 - 3: Kiryu, Akiyama, Saejima, Tanimura
-    short Paradigm: 0x1980D94;      // Unique value for different gameplay modes, menus, etc.
-    byte Start: 0x198C624;          // Black screen / screen fade flag
-    int FileTimer: 0x19A3AC8;       // In-game timer
+    byte EnemyCount: 0x1C590F0, 0x4B3;
+    byte Chapter: 0x1C594E8, 0x640, 0x204;
+    string255 TitleCard: 0x1C70A08, 0x150, 0x1E4, 0x16C, 0x88, 0x28, 0x148, 0x14;
+    byte Character: 0x1C5D4A0;
+    short Paradigm: 0x1C5DB64;
+    byte Start: 0x1C693F4;
+    int FileTimer: 0x1C80888;
 }
 
 state("Yakuza4", "GOG")

--- a/LiveSplit.Yakuza4.asl
+++ b/LiveSplit.Yakuza4.asl
@@ -127,6 +127,11 @@ split
     }
 }
 
+reset
+{
+    return (old.Paradigm == 209 && current.Paradigm == 221);
+}
+
 onReset
 {
     vars.Splits.Clear();

--- a/LiveSplit.Yakuza5.asl
+++ b/LiveSplit.Yakuza5.asl
@@ -10,14 +10,14 @@ state("Yakuza5", "Steam")
 state("Yakuza5", "Game Pass") 
 {
     int Loads: 0x2AB2DF4;
-    int chapter: 0x2C51C24;
+    int chapter: 0x2C51C26;
     string255 TitleCard: 0x21CE5E8, 0x98, 0x11C, 0x2EC, 0x180, 0x1D4, 0xE0, 0x5B4;
 }
 
 state("Yakuza5", "GOG") 
 {
     int Loads: 0x2865ADC;
-    int chapter: 0x1B983E8;
+    int chapter: 0x2FEBBE6;
     string255 TitleCard: 0x1F812A8, 0x15C, 0xEF4, 0x454, 0xD0, 0x10, 0x10, 0x274;
 }
 
@@ -96,7 +96,7 @@ update
 
 isLoading 
 {
-    return (current.chapter != 34 && current.Loads == 2 && version == "Steam" || current.chapter != 2228224 && current.Loads == 2 && version == "Game Pass" || current.chapter !=63 && current.Loads == 2 && version == "GOG");
+    return (current.chapter != 34 && current.Loads == 2);
 }
 
 start

--- a/LiveSplit.Yakuza5.asl
+++ b/LiveSplit.Yakuza5.asl
@@ -69,7 +69,7 @@ startup
             settings.Add("syotitle_04.dds", false, "Part 4", "tsh");
             settings.Add("syotitle_04_01.dds", false, "Abandoned Glory", "tsh");
             settings.Add("syotitle_04_02.dds", false, "Confronting the Past", "tsh");
-            settings.Add("syotitle_04_03.dds", false, "The Price of truth", "tsh");
+            settings.Add("syotitle_04_03.dds", false, "The Price of Truth", "tsh");
             settings.Add("syotitle_04_04.dds", false, "Fleeting Triumph", "tsh");
         settings.Add("fin", true, "Finale", "yak5");
             settings.Add("syotitle_05.dds", false, "Final Part", "fin");
@@ -94,10 +94,10 @@ startup
     }
 }
 
-update
-{
-    print(modules.First().ModuleMemorySize.ToString());
-}
+// update
+// {
+//     print(modules.First().ModuleMemorySize.ToString());
+// }
 
 isLoading 
 {

--- a/LiveSplit.Yakuza5.asl
+++ b/LiveSplit.Yakuza5.asl
@@ -139,6 +139,11 @@ onStart
     timer.IsGameTimePaused = true;
 }
 
+onReset
+{
+    vars.Splits.Clear();
+}
+
 exit
 {
     timer.IsGameTimePaused = true;

--- a/LiveSplit.Yakuza5.asl
+++ b/LiveSplit.Yakuza5.asl
@@ -134,6 +134,11 @@ split
     }
 }
 
+reset
+{
+    return current.Chapter == 0 && old.FileTimer < current.FileTimer && current.FileTimer < 100;
+}
+
 onStart
 {
     timer.IsGameTimePaused = true;

--- a/LiveSplit.Yakuza5.asl
+++ b/LiveSplit.Yakuza5.asl
@@ -1,29 +1,40 @@
-//Collaborative effort by streetbackguy and hoxi
+// Collaborative effort by streetbackguy, hoxi and PlayingLikeAss
 state("Yakuza5", "Steam") 
 {
+    string255 QTE: 0x20071E0, 0x83A;
+    byte QTEPassfail: 0x20071E0, 0x1304;
+    string255 TitleCard: 0x2008438, 0x98, 0x11C, 0x2EC, 0x180, 0x1D4, 0xE0, 0x5B4;
+    byte Chapter: 0x2008A92;
+    // byte Paradigm: 0x200B764;
     byte Loads: 0x28ECC5C;
     int FileTimer: 0x28ED098;
     int MainMenu: 0x28F40FA;
+    // byte Character: 0x28F99F4;
     // byte chapter: 0x3073166;
-    string255 TitleCard: 0x2008438, 0x98, 0x11C, 0x2EC, 0x180, 0x1D4, 0xE0, 0x5B4;
 }
 
-state("Yakuza5", "Game Pass") 
+state("Yakuza5", "Game Pass")
 {
+    string255 QTE: 0x21CD390, 0x83A;
+    byte QTEPassfail: 0x21CD390, 0x1304;
+    string255 TitleCard: 0x21CE5E8, 0x98, 0x11C, 0x2EC, 0x180, 0x1D4, 0xE0, 0x5B4;
+    byte Chapter: 0x21CEC52;
     byte Loads: 0x2AB2DF4;
     int FileTimer: 0x2AB3228;
     int MainMenu: 0x2ABA28A;
     // byte chapter: 0x2C51C26;
-    string255 TitleCard: 0x21CE5E8, 0x98, 0x11C, 0x2EC, 0x180, 0x1D4, 0xE0, 0x5B4;
 }
 
-state("Yakuza5", "GOG") 
+state("Yakuza5", "GOG")
 {
+    string255 QTE: 0x1F80060, 0x83A;
+    byte QTEPassfail: 0x1F80060, 0x1304;
+    string255 TitleCard: 0x1F812B8, 0x98, 0x11C, 0x2EC, 0x180, 0x1D4, 0xE0, 0x5B4;
+    byte Chapter: 0x1F81912;
     byte Loads: 0x2865ADC;
     int FileTimer: 0x2865F18;
     int MainMenu: 0x286CF7A;
     // byte chapter: 0x2FEBBE6;
-    string255 TitleCard: 0x1F812A8, 0x15C, 0xEF4, 0x454, 0xD0, 0x10, 0x10, 0x274;
 }
 
 init 
@@ -78,6 +89,9 @@ startup
             settings.Add("syotitle_05_03.dds", false, "The Survivors", "fin");
             settings.Add("syotitle_05_04.dds", false, "Crossroads", "fin");
             settings.Add("syotitle_05_05.dds", false, "Dreams Fulfilled", "fin");
+            settings.Add("RUN OVER", false, "End of the Run", "fin");
+
+    settings.SetToolTip("RUN OVER", "Splits on the last QTE of the final boss.");
 
     if (timer.CurrentTimingMethod == TimingMethod.RealTime)
     {
@@ -94,11 +108,6 @@ startup
     }
 }
 
-// update
-// {
-//     print(modules.First().ModuleMemorySize.ToString());
-// }
-
 isLoading 
 {
     return current.Loads == 2 && current.FileTimer == old.FileTimer;
@@ -109,9 +118,15 @@ start
     return current.Loads == 2 && current.MainMenu == 1;
 }
 
-//Currently autosplits on every end of chapter save screen
+// Currently autosplits on every end of chapter save screen, and on the final QTE.
 split
-{   
+{
+    if (current.Chapter == 21 && current.QTE == "h10340_aizawa_last" && current.QTEPassfail == 1 && !vars.Splits.Contains("RUN OVER"))
+    {
+        vars.Splits.Add("RUN OVER");
+        return settings["RUN OVER"];
+    }
+
     if (current.TitleCard != old.TitleCard && !vars.Splits.Contains(current.TitleCard))
     {
         vars.Splits.Add(current.TitleCard);

--- a/LiveSplit.Yakuza5.asl
+++ b/LiveSplit.Yakuza5.asl
@@ -3,21 +3,23 @@ state("Yakuza5", "Steam")
 {
     int Loads: 0x28ECC5C;
     int MainMenu: 0x28F40FA;
-    int chapter: 0x3073166;
+    byte chapter: 0x3073166;
     string255 TitleCard: 0x2008438, 0x98, 0x11C, 0x2EC, 0x180, 0x1D4, 0xE0, 0x5B4;
 }
 
 state("Yakuza5", "Game Pass") 
 {
     int Loads: 0x2AB2DF4;
-    int chapter: 0x2C51C26;
+    int MainMenu: 0x2ABA28A;
+    byte chapter: 0x2C51C26;
     string255 TitleCard: 0x21CE5E8, 0x98, 0x11C, 0x2EC, 0x180, 0x1D4, 0xE0, 0x5B4;
 }
 
 state("Yakuza5", "GOG") 
 {
     int Loads: 0x2865ADC;
-    int chapter: 0x2FEBBE6;
+    int MainMenu: 0x286CF7A;
+    byte chapter: 0x2FEBBE6;
     string255 TitleCard: 0x1F812A8, 0x15C, 0xEF4, 0x454, 0xD0, 0x10, 0x10, 0x274;
 }
 
@@ -101,7 +103,7 @@ isLoading
 
 start
 {
-    return (current.Loads == 2 && current.MainMenu == 1 && version == "Steam");
+    return (current.Loads == 2 && current.MainMenu == 1);
 }
 
 //Currently autosplits on every end of chapter save screen

--- a/LiveSplit.Yakuza5.asl
+++ b/LiveSplit.Yakuza5.asl
@@ -1,25 +1,28 @@
 //Collaborative effort by streetbackguy and hoxi
 state("Yakuza5", "Steam") 
 {
-    int Loads: 0x28ECC5C;
+    byte Loads: 0x28ECC5C;
+    int FileTimer: 0x28ED098;
     int MainMenu: 0x28F40FA;
-    byte chapter: 0x3073166;
+    // byte chapter: 0x3073166;
     string255 TitleCard: 0x2008438, 0x98, 0x11C, 0x2EC, 0x180, 0x1D4, 0xE0, 0x5B4;
 }
 
 state("Yakuza5", "Game Pass") 
 {
-    int Loads: 0x2AB2DF4;
+    byte Loads: 0x2AB2DF4;
+    int FileTimer: 0x2AB3228;
     int MainMenu: 0x2ABA28A;
-    byte chapter: 0x2C51C26;
+    // byte chapter: 0x2C51C26;
     string255 TitleCard: 0x21CE5E8, 0x98, 0x11C, 0x2EC, 0x180, 0x1D4, 0xE0, 0x5B4;
 }
 
 state("Yakuza5", "GOG") 
 {
-    int Loads: 0x2865ADC;
+    byte Loads: 0x2865ADC;
+    int FileTimer: 0x2865F18;
     int MainMenu: 0x286CF7A;
-    byte chapter: 0x2FEBBE6;
+    // byte chapter: 0x2FEBBE6;
     string255 TitleCard: 0x1F812A8, 0x15C, 0xEF4, 0x454, 0xD0, 0x10, 0x10, 0x274;
 }
 
@@ -98,12 +101,12 @@ update
 
 isLoading 
 {
-    return (current.chapter != 34 && current.Loads == 2);
+    return current.Loads == 2 && current.FileTimer == old.FileTimer;
 }
 
 start
 {
-    return (current.Loads == 2 && current.MainMenu == 1);
+    return current.Loads == 2 && current.MainMenu == 1;
 }
 
 //Currently autosplits on every end of chapter save screen


### PR DESCRIPTION
**Yakuza 3**
- Autosplitter now works for Game Pass version.
- Added reset functionality, which (carefully) resets the timer based on the splash screen music playing.
- Properly cleared vars.Splits on reset so that autosplitting works correctly on multiple runs.

**Yakuza 4**
- Autosplitter now works for Game Pass version.
- Re-added the auto-reset functionality, which went missing in a prior commit.
- Properly cleared vars.Splits on reset so that autosplitting works correctly on multiple runs.

**Yakuza 5**
- Autosplitter now splits on the final QTE, to end the run.
- Load removal now assisted by IGT, like in 3 and 4. Fixes Saejima hunting traps and file loads.
- Added reset functionality, which (carefully) resets the timer based on chapter number and IGT.
- Properly cleared vars.Splits on reset so that autosplitting works correctly on multiple runs.
- Grabbed MainMenu variable on Game Pass and GOG.

- Every variable in every game now uses the same pointer and functions the same way.