### PR TITLE
Make more use of `asl-help` to simplify the code

### DIFF
--- a/CrowCountry.Settings.xml
+++ b/CrowCountry.Settings.xml
@@ -1,59 +1,77 @@
 <Settings>
-    <Setting Id="ch" Label="Split on completing area:" State="false">
-        <Setting Id="areaRoadside" Label="Roadside" State="true" />
-        <Setting Id="areaEntrance" Label="Entrance" State="true" />
-        <Setting Id="areaToilet" Label="Toilet" State="true" />
-        <Setting Id="areaStation Square" Label="Station Square" State="true" />
-        <Setting Id="areaFairy Forest" Label="Fairy Forest" State="true" />
-        <Setting Id="areaCosmic Cosmos" Label="Cosmic Cosmos" State="true" />
-        <Setting Id="areaCorridor S" Label="Corridor S" State="true" />
-        <Setting Id="areaFairy Pool" Label="Fairy Pool" State="true" />
-        <Setting Id="areaCorridor A" Label="Corridor A" State="true" />
-        <Setting Id="areaDig Site" Label="Dig Site" State="true" />
-        <Setting Id="areaSwan Boats" Label="Swan Boats" State="true" />
-        <Setting Id="areaRailway" Label="Railway" State="true" />
-        <Setting Id="areaHauntedHilltop" Label="Haunted Hilltop" State="true" />
-        <Setting Id="areaDungeon" Label="Dungeon" State="true" />
-        <Setting Id="areaCorridor B" Label="Corridor B" State="true" />
-        <Setting Id="areaCrypt" Label="Crypt" State="true" />
-        <Setting Id="areaCorridor D" Label="Corridor D" State="true" />
-        <Setting Id="areaMachine SE" Label="Machine SE" State="true" />
-        <Setting Id="areaCell" Label="Cell" State="true" />
-        <Setting Id="areaMansion" Label="Mansion" State="true" />
-        <Setting Id="areaOffice Pike" Label="Office Pike" State="true" />
-        <Setting Id="areaTheatre" Label="Theatre" State="true" />
-        <Setting Id="areaMushroom" Label="Mushroom" State="true" />
-        <Setting Id="areaOcean Kingdom" Label="Ocean Kingdom" State="true" />
-        <Setting Id="areaArcade" Label="Arcade" State="true" />
-        <Setting Id="areaSubmarine" Label="Submarine" State="true" />
-        <Setting Id="areaWitchwood" Label="Witchwood" State="true" />
-        <Setting Id="areaRestaurant" Label="Restaurant" State="true" />
-        <Setting Id="areaOffice Tolman" Label="Office Tolman" State="true" />
-        <Setting Id="areaUnderground NW" Label="Underground NW" State="true" />
-        <Setting Id="areaBreak Room" Label="Break Room" State="true" />
-        <Setting Id="areaUnderground NE" Label="Underground NE" State="true" />
-        <Setting Id="areaRoot Sun" Label="Root Sun" State="true" />
-        <Setting Id="areaUnderground SE" Label="Underground SE" State="true" />
-        <Setting Id="areaControl Room" Label="Control Room" State="true" />
-        <Setting Id="areaOffice Crow" Label="Office Crow" State="true" />
-        <Setting Id="areaRoot Sat" Label="Root Sat" State="true" />
-        <Setting Id="areaRoot Fri" Label="Root Fri" State="true" />
-        <Setting Id="areaUnderground SW" Label="Underground SW" State="true" />
-        <Setting Id="areaRoot Thu" Label="Root Thu" State="true" />
-        <Setting Id="areaCorridor C" Label="Corridor C" State="truee" />
-        <Setting Id="areaMachine SW" Label="Machine SW" State="true" />
-        <Setting Id="areaBoat Ride Dock" Label="Boat Ride Dock" State="true" />
-        <Setting Id="areaBoat Ride" Label="Boat Ride" State="true" />
-        <Setting Id="areaRoot Wed" Label="Root Wed" State="truee" />
-        <Setting Id="areaRoot Tue" Label="Root Tue" State="true" />
-        <Setting Id="areaRoot Mon" Label="Root Mon" State="true" />
-        <Setting Id="areaPre Machine Centre" Label="Pre Machine Centre" State="true" />
-        <Setting Id="areaMachine Centre" Label="Machine Centre" State="true" />
-        <Setting Id="areaMid" Label="Mid" State="true" />
-        <Setting Id="areaUnderground Centre" Label="Underground Centre" State="true" />
-        <Setting Id="areaLadder" Label="Ladder" State="true" />
-        <Setting Id="areaUnderground Lab" Label="Underground Lab" State="true" />
-        <Setting Id="areaPool" Label="Pool" State="true" />
-        <Setting Id="areaEnding Sequence" Label="Ending Sequence" State="true" />
+
+    <Setting Label="Split on collecting item:" State="false">
+      <!-- <Setting Id="i-item: 1-1" Label="ID Card" State="true" /> -->
+      <Setting Id="i-item: 2-1" Label="Bronze Key" State="true" />
+      <Setting Id="i-item: 3-1" Label="Silver Key" State="true" />
+      <Setting Id="i-item: 4-1" Label="Gold Key" State="true" />
+      <Setting Id="i-item: 5-1" Label="Crank" State="true" />
+      <Setting Id="i-item: 6-1" Label="Gemstone" State="true" />
+      <Setting Id="i-item: 7-1" Label="Chain" State="true" />
+      <Setting Id="i-item: 8-1" Label="Woeful Mask" State="true" />
+      <Setting Id="i-item: 9-1" Label="Trident" State="true" />
+      <Setting Id="i-item: 10-1" Label="Data Disk" State="true" />
+      <Setting Id="i-item: 11-1" Label="Acid bottle" State="true" />
+      <Setting Id="i-item: 12-1" Label="Large Battery" State="true" />
+      <Setting Id="i-item: 13-1" Label="Glass Vials" State="true" />
     </Setting>
-</Settings>
+
+    <Setting Label="Split on leaving area:" State="false">
+      <Setting Id="ac-Roadside" Label="Roadside" State="true" />
+      <Setting Id="ac-Entrance" Label="Entrance" State="true" />
+      <Setting Id="ac-Toilet" Label="Toilet" State="true" />
+      <Setting Id="ac-Station Square" Label="Station Square" State="true" />
+      <Setting Id="ac-Fairy Forest" Label="Fairy Forest" State="true" />
+      <Setting Id="ac-Cosmic Cosmos" Label="Cosmic Cosmos" State="true" />
+      <Setting Id="ac-Corridor S" Label="Corridor S" State="true" />
+      <Setting Id="ac-Fairy Pool" Label="Fairy Pool" State="true" />
+      <Setting Id="ac-Corridor A" Label="Corridor A" State="true" />
+      <Setting Id="ac-Dig Site" Label="Dig Site" State="true" />
+      <Setting Id="ac-Swan Boats" Label="Swan Boats" State="true" />
+      <Setting Id="ac-Railway" Label="Railway" State="true" />
+      <Setting Id="ac-HauntedHilltop" Label="Haunted Hilltop" State="true" />
+      <Setting Id="ac-Dungeon" Label="Dungeon" State="true" />
+      <Setting Id="ac-Corridor B" Label="Corridor B" State="true" />
+      <Setting Id="ac-Crypt" Label="Crypt" State="true" />
+      <Setting Id="ac-Corridor D" Label="Corridor D" State="true" />
+      <Setting Id="ac-Machine SE" Label="Machine SE" State="true" />
+      <Setting Id="ac-Cell" Label="Cell" State="true" />
+      <Setting Id="ac-Mansion" Label="Mansion" State="true" />
+      <Setting Id="ac-Office Pike" Label="Office Pike" State="true" />
+      <Setting Id="ac-Theatre" Label="Theatre" State="true" />
+      <Setting Id="ac-Mushroom" Label="Mushroom" State="true" />
+      <Setting Id="ac-Ocean Kingdom" Label="Ocean Kingdom" State="true" />
+      <Setting Id="ac-Arcade" Label="Arcade" State="true" />
+      <Setting Id="ac-Submarine" Label="Submarine" State="true" />
+      <Setting Id="ac-Witchwood" Label="Witchwood" State="true" />
+      <Setting Id="ac-Restaurant" Label="Restaurant" State="true" />
+      <Setting Id="ac-Office Tolman" Label="Office Tolman" State="true" />
+      <Setting Id="ac-Underground NW" Label="Underground NW" State="true" />
+      <Setting Id="ac-Break Room" Label="Break Room" State="true" />
+      <Setting Id="ac-Underground NE" Label="Underground NE" State="true" />
+      <Setting Id="ac-Root Sun" Label="Root Sun" State="true" />
+      <Setting Id="ac-Underground SE" Label="Underground SE" State="true" />
+      <Setting Id="ac-Control Room" Label="Control Room" State="true" />
+      <Setting Id="ac-Office Crow" Label="Office Crow" State="true" />
+      <Setting Id="ac-Root Sat" Label="Root Sat" State="true" />
+      <Setting Id="ac-Root Fri" Label="Root Fri" State="true" />
+      <Setting Id="ac-Underground SW" Label="Underground SW" State="true" />
+      <Setting Id="ac-Root Thu" Label="Root Thu" State="true" />
+      <Setting Id="ac-Corridor C" Label="Corridor C" State="truee" />
+      <Setting Id="ac-Machine SW" Label="Machine SW" State="true" />
+      <Setting Id="ac-Boat Ride Dock" Label="Boat Ride Dock" State="true" />
+      <Setting Id="ac-Boat Ride" Label="Boat Ride" State="true" />
+      <Setting Id="ac-Root Wed" Label="Root Wed" State="true" />
+      <Setting Id="ac-Root Tue" Label="Root Tue" State="true" />
+      <Setting Id="ac-Root Mon" Label="Root Mon" State="true" />
+      <Setting Id="ac-Pre Machine Centre" Label="Pre Machine Centre" State="true" />
+      <Setting Id="ac-Machine Centre" Label="Machine Centre" State="true" />
+      <Setting Id="ac-Mid" Label="Mid" State="true" />
+      <Setting Id="ac-Underground Centre" Label="Underground Centre" State="true" />
+      <Setting Id="ac-Ladder" Label="Ladder" State="true" />
+      <Setting Id="ac-Underground Lab" Label="Underground Lab" State="true" />
+      <Setting Id="ac-Pool" Label="Pool" State="true" />
+      <Setting Id="ac-Ending Sequence" Label="Ending Sequence" State="true" />
+    </Setting>
+
+  </Settings>

--- a/LiveSplit.CrowCountry.asl
+++ b/LiveSplit.CrowCountry.asl
@@ -1,228 +1,98 @@
-//Load Removal by Diggity
-//Autosplitter by Streetbackguy
-state("Crow Country")
-{
-}
+// Load Removal by Diggity
+// Autosplitter by Streetbackguy
+
+state("Crow Country") {}
 
 startup
 {
-    vars.Log = (Action<object>)(output => print("[Crow Country] " + output));
-
     Assembly.Load(File.ReadAllBytes("Components/asl-help")).CreateInstance("Unity");
     vars.Helper.LoadSceneManager = true;
+
     vars.Helper.Settings.CreateFromXml("Components/CrowCountry.Settings.xml");
     vars.Helper.AlertLoadless();
 
-    vars.ReadFSMInt = (Func<System.Diagnostics.Process, long, string, int>)((proc, arrayBase, name) =>
-    {
-        DeepPointer dp;
-        int arrayCount;
+    vars.PendingSplits = 0;
+    vars.CompletedSplits = new HashSet<string>();
+}
 
-        dp = new DeepPointer((IntPtr)arrayBase + 0x18);
-        arrayCount = dp.Deref<int>(proc);
-
-        for (var i = 0; i < arrayCount; i++)
-        {
-            String s;
-            int value;
-
-            dp = new DeepPointer((IntPtr)arrayBase + 0x20 + (0x8 * i), 0x10, 0x14);
-            s = dp.DerefString(proc, 64);
-            dp = new DeepPointer((IntPtr)arrayBase + 0x20 + (0x8 * i), 0x30);
-            value = dp.Deref<int>(proc);
-
-            if (s == name) {
-                return value;
-            }
-        }
-
-        throw new Exception("Item Not Found: " + name);
-    });
+onStart
+{
+    vars.CompletedSplits.Clear();
 }
 
 init
 {
-    vars.Splits = new HashSet<string>();
-
     vars.Helper.TryLoad = (Func<dynamic, bool>)(mono =>
     {
         var pm = mono["PlayMaker", "PlayMakerGlobals"];
-        vars.Helper["arrayBase"] = pm.Make<long>("instance", 0x18, 0x30);
-        vars.Helper["Items"] = pm.Make<int>("instance", 0x18, 0x30, 0x18);
+        vars.Helper["IntVariables"] = mono.MakeArray<IntPtr>(pm, "instance", "variables", "intVariables");
 
+        vars.OffsetName = mono["PlayMaker", "NamedVariable"]["name"];
+        vars.OffsetValue = mono["PlayMaker", "FsmInt"]["value"];
 
-        //print("Base address is" + (pm.Static + pm["instance"]).ToString("X"));
+        vars.Helper["IntVariables"].Update(game);
+        IntPtr[] intVariables = vars.Helper["IntVariables"].Current;
 
-        for (var j = 0; j < 238; j++)
-        {
-            DeepPointer dp = new DeepPointer(pm.Static + pm["instance"], 0x18, 0x30, 0x20+(0x8*j), 0x10, 0x14);
-            string s = dp.DerefString(game, 64);
-            dp = new DeepPointer(pm.Static + pm["instance"], 0x18, 0x30, 0x20+(0x8*j), 0x30);
-            int i = dp.Deref<int>(game);
+        if (intVariables.Length == 0)
+            return false;
 
-            print (s + ": " + i.ToString());
-        }
+        vars.IntVariableCount = intVariables.Length; // if this array is ever resized, this would no longer work
+        vars.IntVariableNames = intVariables.Select(entry => vars.Helper.ReadString(entry + vars.OffsetName)).ToArray();
 
         return true;
     });
-
-    //ID Card = Item 1
-    //Bronze Key = Item 2
-    //Silver Key = Item 3
-    //Gold Key = Item 4
-    //Trident = Item 9
-    //Glass Vials
-    //Crank = Item 5
-    //Gemstone = Item 6
-    //Chain = Item 7
-    //Woeful Mask = Item 8
-    //Data Disk = Item 10
-    //Acid bottle = Item 11
-    //Large Battery = Item 12
-    current.GotBronzeKey = 0;
-    current.GotSilverKey = 0;
-    current.GotGoldKey = 0;
-    current.GotWoefulMask = 0;
-    current.GotTrident = 0;
-    current.GotGlassVials = 0;
-    current.GotCrank = 0;
-    current.GotChain = 0;
-    current.GotDataDisk = 0;
-    current.GotAcidBottle = 0;
-    current.GotLargeBattry = 0;
-
-    //current.CrystalCrowCount = 0;
-    //current.Weapons = 0;
 }
 
 update
 {
-	current.activeScene = vars.Helper.Scenes.Active.Name ?? current.activeScene;
-    current.loadingScene = vars.Helper.Scenes.Loaded[0].Name ?? current.loadingScene;
-
-    current.GotBronzeKey = vars.ReadFSMInt(game, current.arrayBase, "item: 2");
-    current.GotCrank = vars.ReadFSMInt(game, current.arrayBase, "item: 5");
-    current.GotGemstone = vars.ReadFSMInt(game, current.arrayBase, "item: 6");
-    current.GotChain = vars.ReadFSMInt(game, current.arrayBase, "item: 7");
-    current.GotWoefulMask = vars.ReadFSMInt(game, current.arrayBase, "item: 8");
-    current.GotSilverKey = vars.ReadFSMInt(game, current.arrayBase, "item: 3");
-    current.GotDataDisk = vars.ReadFSMInt(game, current.arrayBase, "item: 10");
-    current.GotGoldKey = vars.ReadFSMInt(game, current.arrayBase, "item: 4");
-    current.GotLargeBattery = vars.ReadFSMInt(game, current.arrayBase, "item: 12");
-    current.GotTrident = vars.ReadFSMInt(game, current.arrayBase, "item: 9");
-    current.GotGlassVials = vars.ReadFSMInt(game, current.arrayBase, "item: 13");
-    current.GotAcidBottle = vars.ReadFSMInt(game, current.arrayBase, "item: 11");
-
-    //current.CrystalCrowCount = vars.ReadFSMInt(game, current.arrayBase, "CrystalCrows: 0");
-    //current.Weapons = vars.ReadFSMInt(game, current.arrayBase, "total guns: 1");
-}
-
-isLoading
-{
-    return old.loadingScene != current.activeScene;
+    current.ActiveScene = vars.Helper.Scenes.Active.Name ?? current.ActiveScene;
 }
 
 start
 {
-    //return old.loadingScene != current.activeScene && old.loadingScene == "Roadside";
+    // return current.ActiveScene != current.ActiveScene && old.ActiveScene == "Roadside";
 }
 
 split
 {
-    //Key Items
-    if (old.GotBronzeKey == 0 && current.GotBronzeKey == 1)
+    if (vars.PendingSplits > 0)
     {
-        vars.Log("Picked up Bronze Key");
-        return settings["itemBronzeKey"];
+        vars.PendingSplits--;
+        return true;
     }
 
-    if (old.GotCrank == 0 && current.GotCrank == 1)
+    // Items
+    for (int i = 0; i < vars.IntVariableCount; i++)
     {
-        vars.Log("Picked up Crank");
-        return settings["itemCrank"];
+        string name = vars.IntVariableNames[i];
+        int value = vars.Helper.Read<int>(current.IntVariables[i] + vars.OffsetValue);
+
+        string setting = "i-" + name + "-" + value; // i = item
+        if (settings.ContainsKey(setting) && settings[setting] && vars.CompletedSplits.Add(setting))
+        {
+            vars.Log(setting);
+            vars.PendingSplits++;
+        }
     }
 
-    if (old.GotGemstone == 0 && current.GotGemstone == 1)
+    // Areas
+    if (old.ActiveScene != current.ActiveScene)
     {
-        vars.Log("Picked up Gemstone");
-        return settings["itemGemstone"];
+        string setting = "ac-" + old.ActiveScene; // ac = area complete
+        if (settings.ContainsKey(setting) && settings[setting] && vars.CompletedSplits.Add(setting))
+        {
+            vars.Log(setting);
+            vars.PendingSplits++;
+        }
     }
-
-    if (old.GotChain == 0 && current.GotChain == 1)
-    {
-        vars.Log("Picked up Chain");
-        return settings["itemChain"];
-    }
-
-    if (old.GotWoefulMask == 0 && current.GotWoefulMask == 1)
-    {
-        vars.Log("Picked up Woeful Mask");
-        return settings["itemWoefulMask"];
-    }
-
-    if (old.GotSilverKey == 0 && current.GotSilverKey == 1)
-    {
-        vars.Log("Picked up Silver Key");
-        return settings["itemSilverKey"];
-    }
-
-    if (old.GotDataDisk == 0 && current.GotDataDisk == 1)
-    {
-        vars.Log("Picked up Data Disk");
-        return settings["itemDataDisk"];
-    }
-
-    if (old.GotTrident == 0 && current.GotTrident == 1)
-    {
-        vars.Log("Picked up Trident");
-        return settings["itemTrident"];
-    }
-    
-    if (old.GotGoldKey == 0 && current.GotGoldKey == 1)
-    {
-        vars.Log("Picked up Gold Key");
-        return settings["itemGoldKey"];
-    }
-
-    if (old.GotLargeBattery == 0 && current.GotLargeBattery == 1)
-    {
-        vars.Log("Picked up Large Battery");
-        return settings["itemLargeBattery"];
-    }
-
-    if (old.GotGlassVials == 0 && current.GotGlassVials == 1)
-    {
-        vars.Log("Picked up Glass Vials");
-        return settings["itemGlassVials"];
-    }
-
-    if (old.GotAcidBottle == 0 && current.GotAcidBottle == 1)
-    {
-        vars.Log("Picked up Acid Bottle");
-        return settings["itemAcidBottle"];
-    }
-
-    //Area
-    if(old.loadingScene != current.loadingScene && old.loadingScene != "Title" && old.loadingScene != "Driving Intro")
-    {
-        vars.Log("Area completed | " + old.loadingScene);
-        return settings["area" + old.loadingScene];
-    }
-
-    //Secrets
-    // if(old.CrystalCrowCount == current.CrystalCrowCount + 1 && current.loadingScene != "Title")
-    // {
-    //     vars.Log("Crystal Crows | " + current.CrystalCrowCount);
-    //     return settings["secretCrows"];
-    // }
-
-    // if (old.Weapons != current.Weapons && current.Weapons == old.Weapons + 1)
-    // {
-    //     return settings["secretWeapons"];
-    // }
 }
 
 reset
 {
-    return current.activeScene == "Title" && old.activeScene != "Title";
+    return old.ActiveScene != "Title" && current.ActiveScene == "Title";
+}
+
+isLoading
+{
+    return vars.Helper.IsLoading;
 }


### PR DESCRIPTION
Makes more proper use of `asl-help` in `TryLoad`.  
Iterates over the `intVariables` array and checks the values individually. This allows for extensions to be done merely by adding new settings.  
Dropped the use of `loadingScene`, as I didn't see a need for it in my tests.  
Added/renamed/fixed the relevant settings.

Splitting, resetting and load removal seemed to work fine from my tests.