### PR TITLE
Big overhaul for Yakuza 3

### DIFF
--- a/LiveSplit.Yakuza3.asl
+++ b/LiveSplit.Yakuza3.asl
@@ -1,52 +1,43 @@
 state("Yakuza3", "Steam") 
 {
-    byte EnemyCount:  0x1198218, 0x200, 0x491;
-    byte Loads: 0x1198218, 0x310, 0x210;
-    string255 TitleCard: 0x1198218, 0x560, 0xC8, 0x108, 0x14;
-    // short Paradigm: 0x119D778;
+    byte Loads:   0x1198218, 0x310, 0x210;
+    uint NewGame: 0x1198218, 0x3B0, 0x220;
     byte LoadHelper: 0x11AB360;
-    // string255 GolfResults: 0x11C3470, 0x28, 0x5A9;
     int FileTimer: 0x11C6518;
-    byte Start: 0x11C6524;
+    uint    StateCount:   0x122f268, 0x0;
+    byte384 StateEntries: 0x122f268, 0x4;
     byte MusicSlot1State: 0x128B040, 0x40;
     string255 MusicSlot1: 0x128B040, 0x5C;
     byte MusicSlot2State: 0x128B048, 0x40;
     string255 MusicSlot2: 0x128B048, 0x5C;
-    string255 AUXSlot1: 0x128B020, 0x5C;
 }
 
 state("Yakuza3", "Game Pass")
 {
-    byte EnemyCount:  0x144D1C0, 0x200, 0x491;
-    byte Loads: 0x144D1C0, 0x310, 0x210;
-    string255 TitleCard: 0x144D1C0, 0x560, 0xC8, 0x108, 0x14;
-    // short Paradigm: 0x1452738;
+    byte Loads:   0x144D1C0, 0x310, 0x210;
+    uint NewGame: 0x144D1C0, 0x3B0, 0x220;
     byte LoadHelper: 0x1460340;
-    // string255 GolfResults: 0x11C3470, 0x28, 0x5D4;
     int FileTimer: 0x147B498;
-    byte Start: 0x147B4A4;
+    uint    StateCount:   0x14E4338, 0x0;
+    byte384 StateEntries: 0x14E4338, 0x4;
     byte MusicSlot1State: 0x153FE30, 0x40;
     string255 MusicSlot1: 0x153FE30, 0x5C;
     byte MusicSlot2State: 0x153FE38, 0x40;
     string255 MusicSlot2: 0x153FE38, 0x5C;
-    string255 AUXSlot1: 0x153FE10, 0x5C;
 }
 
 state("Yakuza3", "GOG")
 {
-    byte EnemyCount: 0x1132918, 0x200, 0x491;
-    byte Loads: 0x1132918, 0x310, 0x210;
-    string255 TitleCard: 0x1132918, 0x560, 0xC8, 0x108, 0x14;
-    // short Paradigm: 0x1137E78;
+    byte Loads:   0x1132918, 0x310, 0x210;  // CActionManager -> CCCC -> 0x210
+    uint NewGame: 0x1132918, 0x3B0, 0x220;  // CActionManager -> CActionTitle -> 0x220
     byte LoadHelper: 0x1145A60;
-    // string255 GolfResults: 0x115DB70, 0x28, 0x5A9;
     int FileTimer: 0x1160BC8;
-    byte Start: 0x1160BD4;
+    uint    StateCount:   0x11c9958, 0x0;
+    byte384 StateEntries: 0x11c9958, 0x4;
     byte MusicSlot1State: 0x1225710, 0x40;
     string255 MusicSlot1: 0x1225710, 0x5C;
     byte MusicSlot2State: 0x1225718, 0x40;
     string255 MusicSlot2: 0x1225718, 0x5C;
-    string255 AUXSlot1: 0x12256F0, 0x5C;
 }
 
 init
@@ -55,38 +46,79 @@ init
 
     switch(modules.First().ModuleMemorySize) 
     {
-        case 78782464:
-            version = "Game Pass";
-            break; 
         case 47144960:
             version = "Steam";
             break;
         case 46473216:
             version = "GOG";
             break;
+        default: // 49774592?
+            version = "Game Pass";
+            break; 
     }
-
 }
 
 startup
-{   
-    settings.Add("yak3", true, "Yakuza 3 - Chapter End Splits");
-        settings.Add("syotitle_02.dds", true, "Chapter 1: New Beginnings", "yak3");
-        settings.Add("syotitle_03.dds", true, "Chapter 2: The Ryudo Encounter", "yak3");
-        settings.Add("GOLF", false, "Split after Golf", "yak3");
-        settings.Add("syotitle_04.dds", true, "Chapter 3: Power Struggle", "yak3");
-        settings.Add("syotitle_05.dds", true, "Chapter 4: The Man in the Sketch", "yak3");
-        settings.Add("syotitle_06.dds", true, "Chapter 5: The Curtain Rises", "yak3");
-        settings.Add("syotitle_07.dds", true, "Chapter 6: Gameplan", "yak3");
-        settings.Add("syotitle_08.dds", true, "Chapter 7: The Mad Dog", "yak3");
-        settings.Add("syotitle_09.dds", true, "Chapter 8: Conspirators", "yak3");
-        settings.Add("syotitle_10.dds", true, "Chapter 9: The Plot", "yak3");
-        settings.Add("syotitle_11.dds", true, "Chapter 10: Unfinished Business", "yak3");
-        settings.Add("syotitle_12.dds", true, "Chapter 11: Crisis", "yak3");
-        settings.Add("RUN OVER", true, "End of the Run", "yak3");
+{
+    settings.Add("CHAPTER", true, "Chapter End Splits");
+        settings.Add("5-0", true, "Chapter 1: New Beginnings*", "CHAPTER");
+            settings.SetToolTip("5-0", "Splits when Chapter 2 begins, and so on down the line.");
+        settings.Add("6-0", true, "Chapter 2: The Ryudo Encounter", "CHAPTER");
+        settings.Add("7-0", true, "Chapter 3: Power Struggle", "CHAPTER");
+        settings.Add("8-0", true, "Chapter 4: The Man in the Sketch", "CHAPTER");
+        settings.Add("9-0", true, "Chapter 5: The Curtain Rises", "CHAPTER");
+        settings.Add("10-0", true, "Chapter 6: Gameplan", "CHAPTER");
+        settings.Add("11-0", true, "Chapter 7: The Mad Dog", "CHAPTER");
+        settings.Add("12-0", true, "Chapter 8: Conspirators", "CHAPTER");
+        settings.Add("13-0", true, "Chapter 9: The Plot", "CHAPTER");
+        settings.Add("14-0", true, "Chapter 10: Unfinished Business", "CHAPTER");
+        settings.Add("15-0", true, "Chapter 11: Crisis", "CHAPTER");
 
-    settings.SetToolTip("syotitle_02.dds", "Splits when Chapter 2 begins, and so on down the line.");
-    settings.SetToolTip("RUN OVER", "Splits on the last hit on the final boss.");
+    settings.Add("FIGHT", false, "Fight Splits");
+        settings.Add("4-18", false, "Tutorial 1", "FIGHT");
+        settings.Add("4-35", false, "Tutorial 2 (in front of lockers)", "FIGHT");
+        settings.Add("4-46", false, "Majima 1", "FIGHT");
+        settings.Add("5-20", false, "Rikiya", "FIGHT");
+        settings.Add("6-80", false, "Convenience Store Fight", "FIGHT");
+        settings.Add("6-87", false, "Office Antics", "FIGHT");
+        settings.Add("6-89", false, "Tamashiro 1", "FIGHT");
+        settings.Add("7-92", false, "Hasebe", "FIGHT");
+        settings.Add("8-22", false, "Richardson 1", "FIGHT");
+        settings.Add("9-73", false, "Park Fight", "FIGHT");
+        settings.Add("9-82", false, "Hallway Fight", "FIGHT");
+        settings.Add("9-104", false, "Kanda", "FIGHT");
+        settings.Add("10-16", false, "Majima 2", "FIGHT");
+        settings.Add("11-16", false, "West Park Fight*", "FIGHT");
+            settings.SetToolTip("11-16", "After the textboxes.");
+        settings.Add("11-21", false, "Purple Shirt Guy 2", "FIGHT");
+        settings.Add("11-30", false, "Red Shirt Guy", "FIGHT");
+        settings.Add("11-32", false, "Lau Ka Long", "FIGHT");
+        settings.Add("12-41", false, "Cops", "FIGHT"); // Slight guess
+        settings.Add("13-25", false, "Ricky Mask", "FIGHT");
+        settings.Add("13-50", false, "Counterfeit Card Cads", "FIGHT");
+        settings.Add("13-87", false, "Joji Kazama", "FIGHT");
+        settings.Add("14-15", false, "Tamashiro 2", "FIGHT");
+        settings.Add("15-17", false, "Lobby Fight*", "FIGHT");
+            settings.SetToolTip("15-17", "After the textboxes.");
+        settings.Add("15-25", false, "Richardson 2", "FIGHT");
+        settings.Add("15-28", false, "Richardson 3*", "FIGHT");
+            settings.SetToolTip("15-28", "After getting to the elevator.");
+        settings.Add("RUN OVER", false, "Mine*", "FIGHT");
+            settings.SetToolTip("RUN OVER", "Splits on the last hit on the final boss.");
+
+    settings.Add("GOLF", false, "Golf Splits");
+        settings.Add("6-25", false, "Golf Begins", "GOLF");
+        settings.Add("6-31", false, "Hole 1 Results", "GOLF");
+        settings.Add("6-35", false, "Hole 2 Results", "GOLF");
+        settings.Add("6-39", false, "Hole 3 Results", "GOLF");
+        settings.Add("6-40", false, "Leaving the Course*", "GOLF");
+            settings.SetToolTip("6-40", "Alternative to Hole 3");
+
+    settings.Add("CHASE", false, "Chase Splits");
+        settings.Add("8-28", false, "Chase Mack", "CHASE");
+        settings.Add("11-24", false, "Chase Purple Shirt Guy", "CHASE");
+        settings.Add("13-78", false, "Chase Ayako", "CHASE");
+
 
     if (timer.CurrentTimingMethod == TimingMethod.RealTime)
     {
@@ -105,8 +137,8 @@ startup
 
 start
 {
-    // Starts after Selecting Game Difficulty
-    return (current.Start == 0 && old.Start == 1);
+    // Starts after selecting game difficulty.
+    return (current.NewGame == 1 && old.NewGame == 0);
 
     // Starts after the disclaimer
     // return (current.Loads == 1 && old.Loads == 0);
@@ -118,7 +150,6 @@ isLoading
     return (current.LoadHelper == 2 && current.FileTimer == old.FileTimer);
 }
 
-// Currently autosplits on every chapter's title card, and on the last hit on Mine.
 split
 {
     if(current.MusicSlot2.Contains("vs_mine2") && old.MusicSlot2State == 2 && current.MusicSlot2State == 4)
@@ -126,18 +157,24 @@ split
         return settings["RUN OVER"];
     }
 
-    if (current.TitleCard != old.TitleCard && !vars.Splits.Contains(current.TitleCard))
+    // For each scenario state being changed:
+    for(int i = 0; i < current.StateCount; i++)
     {
-        vars.Splits.Add(current.TitleCard);
-        return settings[current.TitleCard.Substring(current.TitleCard.Length - 15)];
-    }
+        int adj = i * 12;
 
-    if (!vars.Splits.Contains("GOLF")
-    && old.AUXSlot1.EndsWith("amb_golf.aix") && !current.AUXSlot1.EndsWith("amb_golf.aix"))
-    // && old.Paradigm == 1613 && current.Paradigm == 933)
-    {
-        vars.Splits.Add("GOLF");
-        return settings["GOLF"];
+        // If the state is being set to true:
+        if (current.StateEntries[8 + adj] == 1)
+        {
+            string s = string.Format("{0}-{1}",
+                BitConverter.ToUInt32(current.StateEntries, adj),       // Scenario section
+                BitConverter.ToUInt32(current.StateEntries, 4 + adj));  // Scenario state
+
+            if (!vars.Splits.Contains(s))
+            {
+                vars.Splits.Add(s);
+                return settings[s];
+            }
+        }
     }
 }
 


### PR DESCRIPTION
- The ASL no longer autostarts on loading a save. We're now using a value from CActionTitle that only gets set when a new game begins.

- StateEntries is an array of 32 structs in CScenarioState, each struct 12 bytes long. Structs are added per frame when new states are to be set in the scenario. The first four bytes are the section of the state (e.g. Chapter 1), the next four bytes are the state's number, and the final four bytes are a 1 or a 0 indicating the new value for the state. Sections and states directly correspond to the file scenario_state.bin from the game files.

- StateCount counts the number of states in the array. When this number is non-zero, we know scenario states are being edited.

- Using the state array, we can track basically every bit of progression in the game. Not only can we split on golf in a more sensible way, we can split on most fights, we can split on chases, we could split on setpieces or cutscenes, we could even split on pickup for individual locker keys. The Mine split is the only one that can't be replaced by this, because scenario state only changes when the fight actually ends.