### PR TITLE
Yakuza 4: Tanimura final split fix-up

### DIFF
--- a/LiveSplit.Yakuza4.asl
+++ b/LiveSplit.Yakuza4.asl
@@ -214,7 +214,7 @@ split
         }
     }
 
-    if (current.Chapter == 17 && current.Character == 3 && old.EnemyCount > 0 && current.EnemyCount == 0 && !vars.Splits.Contains("end"))
+    if (current.Chapter == 17 && current.Character == 3 && vars.Splits.Contains("19-26") && old.EnemyCount > 0 && current.EnemyCount == 0 && !vars.Splits.Contains("end"))
     {
         vars.Splits.Add("end");
         return settings["end"];


### PR DESCRIPTION
Stops the final boss split from misfiring on Amon in ASS%.

The chapter and character indicators are no longer required, but we'll keep them to avoid unnecessary string comparisons.